### PR TITLE
Disable SDK logs from sample appConfig

### DIFF
--- a/public/assets/appConfig.sample.js
+++ b/public/assets/appConfig.sample.js
@@ -7,5 +7,24 @@ var appConfig = {
   //
   // sso: {
   //   accountSid: accountSid
-  // }
+  // },
+  sdkOptions: {
+    worker: {
+      logLevel: "error"
+    },
+    insights: {
+      logLevel: "error"
+    },
+    chat: {
+      logLevel: "error"
+    },
+    flex: {
+      logger: {
+        level: "error"
+      }
+    },
+    voice: {
+      debug: false
+    }
+  }
 }


### PR DESCRIPTION
Reduce the amount of logs shipped out of the box by setting SDKs log levels to `error`

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
