### PR TITLE
Updated dependencies and added craco config

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -1,0 +1,46 @@
+module.exports = {
+  webpack: {
+    configure: (config) => {
+      const fileLoaderRule = getFileLoaderRule(config.module.rules);
+      if (!fileLoaderRule) {
+        throw new Error("File loader not found");
+      }
+      fileLoaderRule.exclude.push(/\.cjs$/);
+
+      config.resolve.fallback = {
+        path: false,
+      };
+
+      config.ignoreWarnings = [ignoreSourcemapsloaderWarnings];
+
+      return config;
+    },
+  },
+};
+
+function getFileLoaderRule(rules) {
+  for (const rule of rules) {
+    if ("oneOf" in rule) {
+      const found = getFileLoaderRule(rule.oneOf);
+      if (found) {
+        return found;
+      }
+    } else if (rule.test === undefined && rule.type === "asset/resource") {
+      return rule;
+    }
+  }
+}
+
+/**
+ *
+ * @param {import('webpack').WebpackError} warning
+ * @returns {boolean}
+ */
+function ignoreSourcemapsloaderWarnings(warning) {
+  return (
+    warning.module &&
+    warning.module.resource.includes("node_modules") &&
+    warning.details &&
+    warning.details.includes("source-map-loader")
+  );
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@twilio/flex-ui": "^2.0.0-beta.1",
+    "@twilio/flex-ui": "^2.0.0",
     "history": "4.7.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
     "history": "4.7.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-scripts": "3.2.0"
+    "react-scripts": "^5.0.1"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "start": "craco start",
+    "build": "craco build",
+    "test": "craco test",
+    "eject": "craco eject"
   },
   "eslintConfig": {
     "extends": "react-app"
@@ -23,5 +23,8 @@
     "not dead",
     "not ie <= 11",
     "not op_mini all"
-  ]
+  ],
+  "devDependencies": {
+    "@craco/craco": "^7.1.0"
+  }
 }


### PR DESCRIPTION
This is due to breaking changes in Webpack 5 and library specific issues

https://www.twilio.com/docs/flex/developer/config/known-issue-react-scripts-version
https://github.com/facebook/create-react-app/discussions/11278#discussioncomment-1780169
https://github.com/facebook/create-react-app/issues/11889#issuecomment-1114928008 
https://gist.github.com/ef4/d2cf5672a93cf241fd47c020b9b3066a

This should make the sample app run and build out of the box with the latest version of `flex-ui`

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
